### PR TITLE
remove esri tags (need to be replaced with 'topics')

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,3 @@ limitations under the License.
 
 A copy of the license is available in the repository's 
 [license.txt](https://raw.github.com/Esri/gis-tools-for-hadoop/master/license.txt) file.
-
-[](Esri Tags: ArcGIS, GIS, Analysis, Big Data, GP, Geoprocessing, Hadoop, Hive, Oozie, Workflow, JSON, Java)
-[](Esri Language: Python)
-


### PR DESCRIPTION
hello! custom markdown tags are no longer hidden.

can you add a `analysis` (and perhaps your previous Esri Tags as new [topics](https://github.com/blog/2309-introducing-topics) when you have a moment please?

we are now showcasing this project in https://esri.github.io and need the `analysis` topic to hydrate our search link.