### PR TITLE
Updated JSON class names for InputFormat & SerDe in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ to provide access to the Hadoop system from the ArcGIS Geoprocessing environment
 
 ## What's New
 
+* [Sample: direct use of Enclosed and Unenclosed Esri- and Geo- JSON InputFormats](samples/json-mr)
+* [Update: use updated non-deprecated names `EsriJsonSerDe` and `EnclosedEsriJsonInputFormat` in samples after having added support for GeoJSON
 * [Tutorial: An Introduction for Beginners] (https://github.com/Esri/gis-tools-for-hadoop/wiki/GIS-Tools-for-Hadoop-for-Beginners)
-* [Tutorial: Aggregating Data Into Bins](https://github.com/Esri/gis-tools-for-hadoop/wiki/Aggregating-CSV-Data-%28Spatial-Binning%29)
-* [Tutorial: Correcting your ArcGIS Projection](https://github.com/Esri/gis-tools-for-hadoop/wiki/Correcting-Projection-in-ArcGIS)
-* [Updated Wiki page for the Spatial-Framework-for-Hadoop](https://github.com/Esri/spatial-framework-for-hadoop/wiki)
+
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to provide access to the Hadoop system from the ArcGIS Geoprocessing environment
 
 * [Sample: direct use of Enclosed and Unenclosed Esri- and Geo- JSON InputFormats](samples/json-mr)
 * Update: use updated non-deprecated names `EsriJsonSerDe` and `EnclosedEsriJsonInputFormat` in samples after having added support for GeoJSON
-* [Tutorial: An Introduction for Beginners] (https://github.com/Esri/gis-tools-for-hadoop/wiki/GIS-Tools-for-Hadoop-for-Beginners)
+* [Tutorial: An Introduction for Beginners](https://github.com/Esri/gis-tools-for-hadoop/wiki/GIS-Tools-for-Hadoop-for-Beginners)
 
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ to provide access to the Hadoop system from the ArcGIS Geoprocessing environment
 ## What's New
 
 * [Sample: direct use of Enclosed and Unenclosed Esri- and Geo- JSON InputFormats](samples/json-mr)
-* [Update: use updated non-deprecated names `EsriJsonSerDe` and `EnclosedEsriJsonInputFormat` in samples after having added support for GeoJSON
+* Update: use updated non-deprecated names `EsriJsonSerDe` and `EnclosedEsriJsonInputFormat` in samples after having added support for GeoJSON
 * [Tutorial: An Introduction for Beginners] (https://github.com/Esri/gis-tools-for-hadoop/wiki/GIS-Tools-for-Hadoop-for-Beginners)
 
 

--- a/samples/json-mr/README.md
+++ b/samples/json-mr/README.md
@@ -14,11 +14,15 @@ hadoop fs -put data/*.json data/
 export HADOOP_CLASSPATH=../lib/esri-geometry-api.jar:../lib/spatial-sdk-hadoop.jar
 libjars="-libjars ../lib/esri-geometry-api.jar,../lib/spatial-sdk-hadoop.jar"
 
-hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${lj} enc esri data/test15eej.json eejs-out
+# hdfs dfs -rmdir eejs-out >/dev/null 2>&1 || /bin/true
+hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${libjars} enc esri data/test15eej.json eejs-out
 
-hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${lj} enc geojs data/test15egj.json egjs-out
+# hdfs dfs -rmdir egjs-out >/dev/null 2>&1
+hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${libjars} enc geojs data/test15egj.json egjs-out
 
-hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${lj} unenc esri data/test15uej.json uejs-out
+# hdfs dfs -rmdir uejs-out >/dev/null 2>&1
+hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${libjars} unenc esri data/test15uej.json uejs-out
 
-hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${lj} unenc geojs data/test15ugj.json ugjs-out
+# hdfs dfs -rmdir ugjs-out >/dev/null 2>&1
+hadoop jar json-mr-sample.jar com.esri.hadoop.examples.json.JsonInputSample ${libjars} unenc geojs data/test15ugj.json ugjs-out
 ```

--- a/samples/point-in-polygon-aggregation-hive/README.md
+++ b/samples/point-in-polygon-aggregation-hive/README.md
@@ -56,9 +56,9 @@ STORED AS TEXTFILE;
 Define a schema for the [California counties data](https://github.com/Esri/gis-tools-for-hadoop/tree/master/samples/data/counties-data).  The counties data is stored as [Enclosed JSON](https://github.com/Esri/spatial-framework-for-hadoop/wiki/JSON-Formats).  
 
 ```sql
-CREATE TABLE counties (Area string, Perimeter string, State string, County string, Name string, BoundaryShape binary)                                         
-ROW FORMAT SERDE 'com.esri.hadoop.hive.serde.JsonSerde'              
-STORED AS INPUTFORMAT 'com.esri.json.hadoop.EnclosedJsonInputFormat'
+CREATE TABLE counties (Area string, Perimeter string, State string, County string, Name string, BoundaryShape binary)                  
+ROW FORMAT SERDE 'com.esri.hadoop.hive.serde.EsriJsonSerDe'
+STORED AS INPUTFORMAT 'com.esri.json.hadoop.EnclosedEsriJsonInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat';
 ```
 

--- a/samples/point-in-polygon-aggregation-hive/run-sample.sql
+++ b/samples/point-in-polygon-aggregation-hive/run-sample.sql
@@ -11,8 +11,8 @@ ROW FORMAT DELIMITED FIELDS TERMINATED BY ','
 LOCATION '${env:HOME}/esri-git/gis-tools-for-hadoop/samples/data/earthquake-data';
 
 CREATE EXTERNAL TABLE IF NOT EXISTS counties (Area string, Perimeter string, State string, County string, Name string, BoundaryShape binary)                                         
-ROW FORMAT SERDE 'com.esri.hadoop.hive.serde.JsonSerde'              
-STORED AS INPUTFORMAT 'com.esri.json.hadoop.EnclosedJsonInputFormat'
+ROW FORMAT SERDE 'com.esri.hadoop.hive.serde.EsriJsonSerDe'              
+STORED AS INPUTFORMAT 'com.esri.json.hadoop.EnclosedEsriJsonInputFormat'
 OUTPUTFORMAT 'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
 LOCATION '${env:HOME}/esri-git/gis-tools-for-hadoop/samples/data/counties-data';
 


### PR DESCRIPTION
Non-deprecated clear naming after adding support for GeoJSON
#66 / #65
(The changes were committed in July but not merged - it may be that the changes hadn't gotten tested - perhaps preempted or that I hit some snag in being able to test.)